### PR TITLE
Add user avatar and greeting to header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,11 @@ const palette = {
   Overdue: "#ef4444",
 };
 
+const user = {
+  name: "Alex Johnson",
+  avatarUrl: "https://i.pravatar.cc/100?img=12",
+};
+
 // ---------- Seed Data ----------
 const SEED = [
   {
@@ -261,6 +266,8 @@ export default function RegulatoryReportsMockup() {
               <button className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border text-sm hover:bg-slate-50">
                 <FilterIcon className="w-4 h-4" /> Save View
               </button>
+              <img src={user.avatarUrl} alt={user.name} className="w-8 h-8 rounded-full" />
+              <span className="hidden md:inline text-sm">Hi, {user.name.split(" ")[0]}</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- show current user avatar and greeting in app header
- define static user object for demo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e086d2ce48330b4f22b90d36bed2a