### PR TITLE
Fix overflowing date range inputs in filter panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -271,7 +271,7 @@ export default function RegulatoryReportsMockup() {
             <section className="xl:col-span-2 space-y-6">
               {/* Controls */}
               <div className="bg-white rounded-2xl border p-4 shadow-sm">
-                <div className="grid grid-cols-1 md:grid-cols-6 gap-3">
+                <div className="grid grid-cols-1 md:grid-cols-7 gap-3">
                   <div className="md:col-span-2 relative">
                     <SearchIcon className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
                     <input
@@ -285,20 +285,20 @@ export default function RegulatoryReportsMockup() {
                   <Select label="Status" value={status} setValue={setStatus} options={["", ...STATUSES]} />
                   <Select label="Frequency" value={freq} setValue={setFreq} options={["", ...FREQS]} />
                   <Select label="Owner" value={owner} setValue={setOwner} options={["", ...owners]} />
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 md:col-span-2">
                     <input
                       type="date"
                       value={dateFrom}
                       onChange={(e) => setDateFrom(e.target.value)}
-                      className="w-full px-3 py-2 rounded-xl border"
+                      className="flex-1 px-3 py-2 rounded-xl border"
                       aria-label="From date"
                     />
-                    <ChevronRight className="w-4 h-4 text-slate-400" />
+                    <ChevronRight className="w-4 h-4 text-slate-400 flex-shrink-0" />
                     <input
                       type="date"
                       value={dateTo}
                       onChange={(e) => setDateTo(e.target.value)}
-                      className="w-full px-3 py-2 rounded-xl border"
+                      className="flex-1 px-3 py-2 rounded-xl border"
                       aria-label="To date"
                     />
                   </div>


### PR DESCRIPTION
## Summary
- prevent filter panel date inputs from spilling under right-side panel by expanding grid and flexing inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e158c46408330823d2eb4aee66796