### PR TITLE
Move metrics chart and quick actions below reports grid

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -311,48 +311,6 @@ export default function RegulatoryReportsMockup() {
                 <Kpi title="Pending Review" value={metrics.byStatus.find((d) => d.name === "Pending Review").value} tone="warn" />
               </div>
 
-              {/* Chart & Helpers */}
-              <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-                <div className="bg-white rounded-2xl border p-4 shadow-sm h-[320px]">
-                  <div className="flex items-center justify-between mb-3">
-                    <h3 className="font-semibold">Overall Report Metrics</h3>
-                    <span className="text-xs text-slate-500">by status</span>
-                  </div>
-                  <div className="h-[240px]">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <PieChart>
-                        <Pie data={metrics.byStatus} dataKey="value" nameKey="name" outerRadius={80} label>
-                          {metrics.byStatus.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={palette[entry.name]} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                        <Legend />
-                      </PieChart>
-                    </ResponsiveContainer>
-                  </div>
-                </div>
-
-                <div className="bg-white rounded-2xl border p-4 shadow-sm space-y-3">
-                  <h3 className="font-semibold">Quick Actions</h3>
-                  <div className="grid grid-cols-2 gap-3">
-                    <button className="justify-between inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:bg-slate-50">
-                      SLA Breaches <span className="ml-auto inline-flex items-center justify-center w-7 h-7 rounded-full bg-rose-100 text-rose-700 text-xs">{metrics.overdue}</span>
-                    </button>
-                    <button className="justify-between inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:bg-slate-50">
-                      Checker Queue <span className="ml-auto inline-flex items-center justify-center w-7 h-7 rounded-full bg-amber-100 text-amber-700 text-xs">{metrics.byStatus.find((d) => d.name === "Pending Review").value}</span>
-                    </button>
-                    <button className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:bg-slate-50">
-                      Refresh Data
-                    </button>
-                    <button className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:bg-slate-50">
-                      Manage Subscriptions
-                    </button>
-                  </div>
-                </div>
-
-              </div>
-
               {/* Table */}
               <div className="bg-white rounded-2xl border shadow-sm">
                 <div className="overflow-x-auto">
@@ -416,6 +374,48 @@ export default function RegulatoryReportsMockup() {
                     <button className="px-2 py-1 rounded-lg border bg-white">Next</button>
                   </div>
                 </div>
+              </div>
+
+              {/* Chart & Helpers */}
+              <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                <div className="bg-white rounded-2xl border p-4 shadow-sm h-[320px]">
+                  <div className="flex items-center justify-between mb-3">
+                    <h3 className="font-semibold">Overall Report Metrics</h3>
+                    <span className="text-xs text-slate-500">by status</span>
+                  </div>
+                  <div className="h-[240px]">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie data={metrics.byStatus} dataKey="value" nameKey="name" outerRadius={80} label>
+                          {metrics.byStatus.map((entry, index) => (
+                            <Cell key={`cell-${index}`} fill={palette[entry.name]} />
+                          ))}
+                        </Pie>
+                        <Tooltip />
+                        <Legend />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </div>
+                </div>
+
+                <div className="bg-white rounded-2xl border p-4 shadow-sm space-y-3">
+                  <h3 className="font-semibold">Quick Actions</h3>
+                  <div className="grid grid-cols-2 gap-3">
+                    <button className="justify-between inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:bg-slate-50">
+                      SLA Breaches <span className="ml-auto inline-flex items-center justify-center w-7 h-7 rounded-full bg-rose-100 text-rose-700 text-xs">{metrics.overdue}</span>
+                    </button>
+                    <button className="justify-between inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:bg-slate-50">
+                      Checker Queue <span className="ml-auto inline-flex items-center justify-center w-7 h-7 rounded-full bg-amber-100 text-amber-700 text-xs">{metrics.byStatus.find((d) => d.name === "Pending Review").value}</span>
+                    </button>
+                    <button className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:bg-slate-50">
+                      Refresh Data
+                    </button>
+                    <button className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:bg-slate-50">
+                      Manage Subscriptions
+                    </button>
+                  </div>
+                </div>
+
               </div>
             </div>
         </main>


### PR DESCRIPTION
## Summary
- Reorder layout so overall report metrics chart and quick actions display beneath the reports table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f122242988330bc17022f250e44a6